### PR TITLE
speedup tailpod by only requesting up to 200 loglines

### DIFF
--- a/killpods
+++ b/killpods
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+kubectl get pods --all-namespaces -o wide --no-headers | fzf -m | awk '{print "kubectl -n " $1 " delete pod " $2 " --grace-period=0 --force"}' | sh

--- a/tailpod
+++ b/tailpod
@@ -18,8 +18,9 @@ tailpod() {
     | tr ' ' '\n' \
     | fzf $(echo $fzf_args))
 
-  _kube_fzf_echo "kubectl logs --namespace='$namespace' --follow $pod_name -c $container_name"
-  kubectl logs --namespace=$namespace --follow $pod_name -c $container_name
+  CMD="kubectl logs --namespace='$namespace' --follow $pod_name -c $container_name --tail=200"
+  _kube_fzf_echo $CMD
+  echo $CMD | sh
   return $(_kube_fzf_teardown 0)
 }
 


### PR DESCRIPTION
I have pods that log heavily. tailpod would result in a few minutes of scrolling before actually starting to follow  recent log lines.

This also ensures that the cmdline printed to stdout is the same code as runs. 

ps. really like your utilities, these should be part of every k8s install :)