### PR TITLE
[Pfpod] Open in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ execpod [-a | -n <namespace-query>] [pod-query] <command>
 ### `pfpod`
 
 ```
-pfpod [-a | -n <namespace-query>] [pod-query] <port>
+pfpod [-o | -a | -n <namespace-query>] [pod-query] <port>
 ```
 
 #### Options

--- a/execpod
+++ b/execpod
@@ -6,7 +6,7 @@ execpod() {
   local namespace_query pod_query cmd result namespace pod_name
 
   _kube_fzf_handler "execpod" "$@" || return $(_kube_fzf_teardown 1)
-  IFS=$'|' read -r namespace_query pod_query cmd <<< "$args"
+  IFS=$'|' read -r namespace_query pod_query cmd _unused <<< "$args"
 
   result=$(_kube_fzf_search_pod "$namespace_query" "$pod_query")
   [ $? -ne 0 ] && echo "$result" && return $(_kube_fzf_teardown 1)

--- a/kube-fzf.sh
+++ b/kube-fzf.sh
@@ -30,12 +30,13 @@ EOF
 
 _kube_fzf_handler() {
   local opt namespace_query pod_query cmd
+  open=false
   local OPTIND=1
   local func=$1
 
   shift $((OPTIND))
 
-  while getopts ":hn:a" opt; do
+  while getopts ":hn:ao" opt; do
     case $opt in
       h)
         _kube_fzf_usage "$func"
@@ -46,6 +47,9 @@ _kube_fzf_handler() {
         ;;
       a)
         namespace_query="--all-namespaces"
+        ;;
+      o)
+        open=true
         ;;
       \?)
         echo "Invalid Option: -$OPTARG."

--- a/kube-fzf.sh
+++ b/kube-fzf.sh
@@ -76,7 +76,13 @@ _kube_fzf_handler() {
         fi
       fi
     else
-      [ -z "$cmd" ] && cmd="sh"
+      if [ -z "$cmd" ]; then
+        if [ "$func" = "execpod" ]; then
+          cmd="sh"
+        elif [ "$func" = "pfpod" ]; then
+          echo "Port required." && _kube_fzf_usage "$func" && return 1
+        fi
+      fi
     fi
   else
     pod_query=$1

--- a/kube-fzf.sh
+++ b/kube-fzf.sh
@@ -14,7 +14,8 @@ _kube_fzf_usage() {
       echo -e "execpod [-a | -n <namespace-query>] [pod-query] <command>\n"
       ;;
     pfpod)
-      echo -e "pfpod [-a | -n <namespace-query>] [pod-query] <port>\n"
+      echo -e "pfpod [ -o | -a | -n <namespace-query>] [pod-query] <port>\n"
+      echo "-o                    -  Open in Browser after port-forwarding"
       ;;
     describepod)
       echo -e "describepod [-a | -n <namespace-query>] [pod-query]\n"

--- a/kube-fzf.sh
+++ b/kube-fzf.sh
@@ -30,7 +30,7 @@ EOF
 
 _kube_fzf_handler() {
   local opt namespace_query pod_query cmd
-  open=false
+  local open=false
   local OPTIND=1
   local func=$1
 
@@ -92,7 +92,7 @@ _kube_fzf_handler() {
     pod_query=$1
   fi
 
-  args="$namespace_query|$pod_query|$cmd"
+  args="$namespace_query|$pod_query|$cmd|$open"
 }
 
 _kube_fzf_fzf_args() {

--- a/pfpod
+++ b/pfpod
@@ -3,10 +3,10 @@
 source ./kube-fzf.sh
 
 pfpod() {
-  local namespace_query pod_query port result namespace pod_name
+  local namespace_query pod_query port result namespace pod_name open
 
   _kube_fzf_handler "pfpod" "$@" || return $(_kube_fzf_teardown 1)
-  IFS=$'|' read -r namespace_query pod_query port <<< "$args"
+  IFS=$'|' read -r namespace_query pod_query port open <<< "$args"
 
   result=$(_kube_fzf_search_pod "$namespace_query" "$pod_query")
   [ $? -ne 0 ] && echo "$result" && return $(_kube_fzf_teardown 1)
@@ -22,7 +22,7 @@ pfpod() {
 
 open_in_browser() {
   IFS=':' read -ra splitted_port <<< "$1"
-  (sleep 3 && echo "Opening in localhost:${splitted_port}" && open "http://localhost:${splitted_port}") &
+  (sleep 3 && echo "Opening localhost:${splitted_port}" && open "http://localhost:${splitted_port}") &
 }
 
 pfpod "$@"

--- a/pfpod
+++ b/pfpod
@@ -15,8 +15,14 @@ pfpod() {
   local fzf_args=$(_kube_fzf_fzf_args "" "--select-1")
 
   _kube_fzf_echo "kubectl port-forward --namespace='$namespace' $pod_name $port"
+  $open && open_in_browser $port
   kubectl port-forward --namespace=$namespace $pod_name $port
   return $(_kube_fzf_teardown 0)
+}
+
+open_in_browser() {
+  IFS=':' read -ra splitted_port <<< "$1"
+  (sleep 3 && echo "Opening in localhost:${splitted_port}" && open "http://localhost:${splitted_port}") &
 }
 
 pfpod "$@"


### PR DESCRIPTION
Made two commits as part of this PR:

1) Make port mandatory argument for pfpod

**Previously**
```bash
$ pfpod
 kubectl port-forward --namespace='default' pod-name sh
 error: Pod 'pod-name' does not have a named port 'sh'
```
   **With this commit**
```bash
$ pfpod
Port required.

USAGE:

pfpod [-a | -n <namespace-query>] [pod-query] <port>

-a                    -  Search in all namespaces
-n <namespace-query>  -  Find namespaces matching <namespace-query> and do fzf.
                         If there is only one match then it is selected automatically.
-h                    -  Show help
```

2. Add Flag to pfpod to open in browser after port forwarding
**Usage:**
```bash
$pfpod -o -n default 8600:8500
$pfpod  -n -o default 8600:8500
$pfpod -o 8600
```
> All the above will open `http://localhost:8600` after 3 seconds(waiting for port-forward).