### PR TITLE
Add double hyphen in the kubectl exec command

### DIFF
--- a/execpod
+++ b/execpod
@@ -19,8 +19,8 @@ execpod() {
     | tr ' ' '\n' \
     | fzf $(echo $fzf_args))
 
-  _kube_fzf_echo "kubectl exec --namespace='$namespace' $pod_name -c $container_name -it $cmd"
-  kubectl exec --namespace=$namespace $pod_name -c $container_name -it $cmd
+  _kube_fzf_echo "kubectl exec --namespace='$namespace' $pod_name -c $container_name -it -- $cmd"
+  kubectl exec --namespace=$namespace $pod_name -c $container_name -it -- $cmd
 }
 
 execpod "$@"


### PR DESCRIPTION
Signed-off-by: Dinesh <dineshudt17@gmail.com>

Fixes https://github.com/thecasualcoder/kube-fzf/issues/25