### PR TITLE
doc(README): add reference to AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ brew tap thecasualcoder/stable
 brew install kube-fzf
 ```
 
+### Using AUR ( ArchLinux )
+```shell
+yay -S kube-fzf
+```
+
 ### Manual
 
 ```


### PR DESCRIPTION
Adding a reference to the AUR package which can be installed on all distributions based on ArchLinux and some others. 